### PR TITLE
[improve][client] allow override of default jsr310 conversion

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
-import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabledFromSchemaInfo;
+import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabled;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseSchemaInfo;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -53,9 +53,9 @@ public class AvroSchema<T> extends AvroBaseStructSchema<T> {
     private AvroSchema(SchemaInfo schemaInfo, ClassLoader pojoClassLoader) {
         super(schemaInfo);
         this.pojoClassLoader = pojoClassLoader;
-        boolean jsr310ConversionEnabled = getJsr310ConversionEnabledFromSchemaInfo(schemaInfo);
+        boolean jsr310ConversionEnabled = getJsr310ConversionEnabled(schemaInfo);
         setReader(new MultiVersionAvroReader<>(schema, pojoClassLoader,
-                getJsr310ConversionEnabledFromSchemaInfo(schemaInfo)));
+                getJsr310ConversionEnabled(schemaInfo)));
         setWriter(new AvroWriter<>(schema, jsr310ConversionEnabled));
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema.reader;
 
-import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabledFromSchemaInfo;
+import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabled;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseAvroSchema;
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.SchemaReader;
@@ -49,7 +49,7 @@ public class MultiVersionAvroReader<T> extends AbstractMultiVersionAvroBaseReade
                         SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
                         schemaInfo.getSchemaDefinition(), schemaInfo);
             }
-            boolean jsr310ConversionEnabled = getJsr310ConversionEnabledFromSchemaInfo(schemaInfo);
+            boolean jsr310ConversionEnabled = getJsr310ConversionEnabled(schemaInfo);
             return new AvroReader<>(parseAvroSchema(schemaInfo.getSchemaDefinition()),
                     readerSchema, pojoClassLoader, jsr310ConversionEnabled);
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
@@ -33,7 +33,16 @@ import org.apache.pulsar.common.schema.SchemaType;
 
 public class SchemaUtil {
 
-    public static boolean getJsr310ConversionEnabledFromSchemaInfo(SchemaInfo schemaInfo) {
+    private static Boolean globalJsr310ConversionEnabled = null;
+
+    public static void setGlobalJsr310ConversionEnabled(Boolean globalJsr310ConversionEnabled) {
+        SchemaUtil.globalJsr310ConversionEnabled = globalJsr310ConversionEnabled;
+    }
+
+    public static boolean getJsr310ConversionEnabled(SchemaInfo schemaInfo) {
+        if (globalJsr310ConversionEnabled != null) {
+            return globalJsr310ConversionEnabled;
+        }
         if (schemaInfo != null) {
             return Boolean.parseBoolean(schemaInfo.getProperties()
                     .getOrDefault(SchemaDefinitionBuilderImpl.JSR310_CONVERSION_ENABLED, "false"));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/util/SchemaUtilTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/util/SchemaUtilTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema.util;
+
+import static org.apache.pulsar.client.impl.schema.SchemaDefinitionBuilderImpl.JSR310_CONVERSION_ENABLED;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.testng.annotations.Test;
+
+public class SchemaUtilTest {
+
+    @Test
+    public void schemaWithoutJsr310EnabledPropertyReturnsFalse() {
+        SchemaUtil.setGlobalJsr310ConversionEnabled(null);
+        SchemaInfo schemaInfo = emptyPropertiesSchema();
+        boolean isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(schemaInfo);
+        assertFalse(isJsr310Enabled);
+    }
+
+    @Test
+    public void schemaWithJsr310DisabledPropertyReturnsFalse() {
+        SchemaUtil.setGlobalJsr310ConversionEnabled(null);
+        SchemaInfo schemaInfo = disabledJsr310PropertiesSchema();
+        boolean isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(schemaInfo);
+        assertFalse(isJsr310Enabled);
+    }
+
+    @Test
+    public void schemaWithJsr310EnabledPropertyReturnsTrue() {
+        SchemaUtil.setGlobalJsr310ConversionEnabled(null);
+        SchemaInfo schemaInfo = enabledJsr310PropertiesSchema();
+        boolean isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(schemaInfo);
+        assertTrue(isJsr310Enabled);
+    }
+
+    @Test
+    public void globalJsr310DisabledAlwaysReturnsFalse() {
+        SchemaUtil.setGlobalJsr310ConversionEnabled(false);
+        boolean isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(emptyPropertiesSchema());
+        assertFalse(isJsr310Enabled);
+        isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(disabledJsr310PropertiesSchema());
+        assertFalse(isJsr310Enabled);
+        isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(enabledJsr310PropertiesSchema());
+        assertFalse(isJsr310Enabled);
+    }
+
+    @Test
+    public void globalJsr310EnabledAlwaysReturnsTrue() {
+        SchemaUtil.setGlobalJsr310ConversionEnabled(true);
+        boolean isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(emptyPropertiesSchema());
+        assertTrue(isJsr310Enabled);
+        isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(disabledJsr310PropertiesSchema());
+        assertTrue(isJsr310Enabled);
+        isJsr310Enabled = SchemaUtil.getJsr310ConversionEnabled(enabledJsr310PropertiesSchema());
+        assertTrue(isJsr310Enabled);
+    }
+
+    private static SchemaInfo emptyPropertiesSchema() {
+        return SchemaInfo.builder()
+                .schema("{\"type\": \"string\"}".getBytes())
+                .type(SchemaType.AVRO)
+                .name("unitTest")
+                .properties(new HashMap<>())
+                .build();
+    }
+
+    private static SchemaInfo disabledJsr310PropertiesSchema() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JSR310_CONVERSION_ENABLED, "false");
+
+        return SchemaInfo.builder()
+                .schema("{\"type\": \"string\"}".getBytes())
+                .type(SchemaType.AVRO)
+                .name("unitTest")
+                .properties(properties)
+                .build();
+    }
+
+    private static SchemaInfo enabledJsr310PropertiesSchema() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JSR310_CONVERSION_ENABLED, "true");
+
+        return SchemaInfo.builder()
+                .schema("{\"type\": \"string\"}".getBytes())
+                .type(SchemaType.AVRO)
+                .name("unitTest")
+                .properties(properties)
+                .build();
+    }
+
+}


### PR DESCRIPTION
### Motivation

There are avro schemas that do not include any properties. Allow setting the default global of jsr310 conversion to true if the client already generated java objects using that avro schema

### Modifications

Keep current functionality but allow a pulsar client user to change the default global jsr310 conversion to true

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Unit tests added for SchemaUtilTest

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/adrianiacobghiula/pulsar/pull/2

https://github.com/adrianiacobghiula/pulsar/actions/runs/18152866281